### PR TITLE
#145 ignore empty questions inserting editing intents

### DIFF
--- a/app/src/components/ToolbarName.js
+++ b/app/src/components/ToolbarName.js
@@ -69,7 +69,17 @@ export default class ToolbarName extends Component {
     }
 
     handleClick() {
-        this.props.saveData(this.props.item);
+        let realContent = [];
+        let newIntent = this.props.item;
+
+        this.props.item.samples.forEach(content => {
+            if (content.trim().length !== 0) { 
+              realContent.push(content);
+            }
+        });
+        newIntent.samples = realContent;
+        //console.log("Formatado:", newIntent);
+        this.props.saveData(newIntent);
     }
 
     handleDelete() {

--- a/app/src/components/ToolbarName.js
+++ b/app/src/components/ToolbarName.js
@@ -72,14 +72,18 @@ export default class ToolbarName extends Component {
         let realContent = [];
         let newIntent = this.props.item;
 
-        this.props.item.samples.forEach(content => {
-            if (content.trim().length !== 0) { 
-              realContent.push(content);
-            }
-        });
-        newIntent.samples = realContent;
+        if (this.props.item.samples !== undefined) {
+            this.props.item.samples.forEach(content => {
+                if (content.trim().length !== 0) { 
+                  realContent.push(content);
+                }
+            });
+            newIntent.samples = realContent;
+            this.props.saveData(newIntent);
+        } else {
+            this.props.saveData(this.props.item);
+        }
         //console.log("Formatado:", newIntent);
-        this.props.saveData(newIntent);
     }
 
     handleDelete() {

--- a/app/src/ducks/intents.js
+++ b/app/src/ducks/intents.js
@@ -59,6 +59,7 @@ export const undoDeleteIntentContent = (state = INITIAL_STATE) => {
 export const selectIntent = (state = INITIAL_STATE, action) => {
     let selected_item = action.item;
     let selected_item_position = action.item_position;
+    let nonEmptySamples=[];
     
     if (selected_item_position < 0) {
         state.intents.find((item, index) => {
@@ -66,6 +67,14 @@ export const selectIntent = (state = INITIAL_STATE, action) => {
             return (item.id === action.item.id || item.name === action.item.name);
         });
     }
+
+    selected_item.samples.forEach(sample => {
+        if (sample.trim().length !== 0) { 
+          nonEmptySamples.push(sample);
+        } 
+    });
+
+    selected_item.samples=nonEmptySamples;
 
     return {
         ...state,

--- a/app/src/ducks/utters.js
+++ b/app/src/ducks/utters.js
@@ -82,6 +82,16 @@ export const selectUtter = (state = INITIAL_STATE, action) => {
         });
     }
 
+    
+    for (let i=0; i< selected_item.alternatives[0].length; i++) {
+        if (selected_item.alternatives[0][i].trim().length === 0){
+            selected_item.alternatives[0].splice(i, 1);
+            console.log("ACERTOU!: ", selected_item.alternatives[0]);
+        };
+    }
+
+
+
     return {
         ...state,
         helper_text: "",

--- a/app/src/pages/IntentPage.js
+++ b/app/src/pages/IntentPage.js
@@ -46,15 +46,25 @@ class IntentPage extends Component {
   }
 
   checkEmptyFieldsIntent(samples) {
-    let changed = true;
+    let status = true;
+    let emptyField = false;
+    let fullfilledIntents = 0;
     if (samples !== undefined) {
       samples.forEach(sample => {
-        if (sample.trim().length === 0) {
-          changed = false;
+        if (sample.trim().length === 0) { 
+          emptyField = true;
+        } else {
+          fullfilledIntents++;
         }
       });
+
+      if (fullfilledIntents === 0 && emptyField) {
+        status = false;
+      } else {
+        status = true;
+      }
     }
-    return changed;
+    return status;
   }
 
   isButtonEnabled() {

--- a/app/src/utils/url_routes.js
+++ b/app/src/utils/url_routes.js
@@ -1,4 +1,4 @@
-export const BASE = process.env.REACT_APP_URL_API + 'api/v1/';
+export const BASE = 'http://localhost:8000/api/v1/'; 
 export const ITEMS_BASE = BASE + 'projects/1/';
 
 export const UTTER_URL = ITEMS_BASE + "utters/";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 3000:3000
     environment:
-       REACT_APP_URL_API: http://localhost:8000/ # API 
+       REACT_APP_URL_API: http://localhost:8000/ #API
     stdin_open: true
     volumes:
       - ./app:/botflow/


### PR DESCRIPTION
According to the needs of #145, this PR is solving the problems described. 

- Now, when inserting or editting an intent, the user can leave empty ballons (as longs as they are not the only content), so it continues to stimulate him to add more content;
- Empty ballons are not saved to the database anymore;
- If present, empty balloons are removed from the utters upon loading;


This Pull Request resolves #145 